### PR TITLE
Fix overlapping elements outside the document

### DIFF
--- a/frontend/javascript/components/document.vue
+++ b/frontend/javascript/components/document.vue
@@ -634,6 +634,10 @@ export default {
 </script>
 
 <style lang="scss">
+.document {
+  position: relative;
+  z-index: 0;
+}
 .toolbar {
   position: sticky;
   top: 0;


### PR DESCRIPTION
`.toolbar` uses a `z-index` that can lead to undesirable overlapping.
See for example https://github.com/okfde/fragdenstaat_de/issues/157
This can be fixed by creating a new stacking context for `.document`.
A new stacking context could have been created with `isolation: isolate`,
but `position: relative; z-index: 0;` is more widely supported.