### PR TITLE
Add pre-commit & make webp dependency optional

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+b7f7bd12f143687a3e720ffce191452ca90bcfbd

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        args: ['--profile', 'black', '--filter-files']
+  - repo: https://github.com/psf/black
+    rev: '22.3.0' # Replace by any tag/version: https://github.com/psf/black/tags
+    hooks:
+      - id: black
+        language_version: python3 # Should be a command that runs python3.6+
+  - repo: https://github.com/pycqa/flake8
+    rev: '3.9.2' # pick a git hash / tag to point to
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear==21.4.3]
+        exclude: ^.*/migrations/.*$
+exclude: ^.*/migrations/.*$

--- a/fc_project/settings.py
+++ b/fc_project/settings.py
@@ -7,41 +7,40 @@ DEBUG = True
 ALLOWED_HOSTS = ["*"]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
 INSTALLED_APPS = [
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.auth',
-    'django.contrib.messages',
-    'django.contrib.admin',
-    'django.contrib.sites',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'django_filters',
-    'taggit',
-    'django_json_widget',
-
-    'filingcabinet',
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.auth",
+    "django.contrib.messages",
+    "django.contrib.admin",
+    "django.contrib.sites",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "django_filters",
+    "taggit",
+    "django_json_widget",
+    "filingcabinet",
 ]
 
-FILINGCABINET_DOCUMENT_MODEL = 'filingcabinet.Document'
-FILINGCABINET_DOCUMENTCOLLECTION_MODEL = 'filingcabinet.DocumentCollection'
-FILINGCABINET_MEDIA_PUBLIC_PREFIX = 'docs'
-FILINGCABINET_MEDIA_PRIVATE_PREFIX = 'docs-private'
+FILINGCABINET_DOCUMENT_MODEL = "filingcabinet.Document"
+FILINGCABINET_DOCUMENTCOLLECTION_MODEL = "filingcabinet.DocumentCollection"
+FILINGCABINET_MEDIA_PUBLIC_PREFIX = "docs"
+FILINGCABINET_MEDIA_PRIVATE_PREFIX = "docs-private"
 
 
 MIDDLEWARE = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
-ROOT_URLCONF = 'fc_project.urls'
+ROOT_URLCONF = "fc_project.urls"
 
 # FIXTURE_DIRS = [os.path.join(test_dir, 'fixtures'), ]
 
@@ -49,27 +48,27 @@ SITE_ID = 1
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'DIRS': [BASE_DIR / 'templates'],
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "DIRS": [BASE_DIR / "templates"],
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Enable time-zone support
 USE_TZ = True
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 # Required for django-webtest to work
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # Random secret key
 
@@ -77,33 +76,31 @@ SECRET_KEY = 'hTuFaTK;N3>hgE9@"*=[mY@)Nk[6g(PEMbOnP?&2@QyyCaGDjw'
 
 # Logs all newsletter app messages to the console
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
         },
     },
-    'loggers': {
-        'newsletter': {
-            'handlers': ['console'],
-            'propagate': True,
+    "loggers": {
+        "newsletter": {
+            "handlers": ["console"],
+            "propagate": True,
         },
     },
 }
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.SessionAuthentication',
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
     ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ),
-    'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
+    "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
+    "DEFAULT_RENDERER_CLASSES": (
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
     ),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
-    )
 }

--- a/fc_project/urls.py
+++ b/fc_project/urls.py
@@ -5,24 +5,24 @@ from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from filingcabinet.api_views import (
-    PageViewSet, DocumentViewSet, DocumentCollectionViewSet,
-    PageAnnotationViewSet
+    DocumentCollectionViewSet,
+    DocumentViewSet,
+    PageAnnotationViewSet,
+    PageViewSet,
 )
 
 api_router = DefaultRouter()
 
-api_router.register(r'document', DocumentViewSet, basename='document')
+api_router.register(r"document", DocumentViewSet, basename="document")
 api_router.register(
-    r'documentcollection',
-    DocumentCollectionViewSet, basename='documentcollection')
-api_router.register(r'page', PageViewSet, basename='page')
-api_router.register(
-    r'pageannotation', PageAnnotationViewSet,
-    basename='pageannotation')
+    r"documentcollection", DocumentCollectionViewSet, basename="documentcollection"
+)
+api_router.register(r"page", PageViewSet, basename="page")
+api_router.register(r"pageannotation", PageAnnotationViewSet, basename="pageannotation")
 
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('documents/', include('filingcabinet.urls')),
-    path('api/', include((api_router.urls, 'api'))),
+    path("admin/", admin.site.urls),
+    path("documents/", include("filingcabinet.urls")),
+    path("api/", include((api_router.urls, "api"))),
 ]

--- a/filingcabinet/admin.py
+++ b/filingcabinet/admin.py
@@ -154,10 +154,11 @@ class DocumentBaseAdmin(admin.ModelAdmin):
 
     fix_document_paths.short_description = _("Fix document paths")
 
-    def publish_documents(
-        self, request, queryset, public=True, message=_("Publishing {} documents...")
-    ):
+    def publish_documents(self, request, queryset, public=True, message=None):
         from .tasks import publish_document
+
+        if message is None:
+            message = _("Publishing {} documents...")
 
         count = 0
         for instance in queryset:

--- a/filingcabinet/services.py
+++ b/filingcabinet/services.py
@@ -207,7 +207,7 @@ def fix_file_paths(doc):
 
 def fix_file_paths_for_page(page):
     changed = False
-    for size_name, width in (("original", -1),) + Page.SIZES:
+    for size_name, _ in (("original", -1),) + Page.SIZES:
         if size_name == "original":
             field_file = page.image
         else:
@@ -354,7 +354,7 @@ def convert_page_to_webp(page):
         buf = encode_to_webp(pil_image, config=webp_config)
         page.image.storage.save("{}.webp".format(page.image.name), ContentFile(buf))
 
-    for size_name, width in Page.SIZES:
+    for size_name, _ in Page.SIZES:
         field_file = getattr(page, "image_%s" % size_name)
         if not field_file:
             continue

--- a/manage.py
+++ b/manage.py
@@ -6,10 +6,10 @@ import sys
 
 def main():
     # Add directory to Python module import paht
-    app_dir = os.path.join(os.path.dirname(__file__), '..')
+    app_dir = os.path.join(os.path.dirname(__file__), "..")
     sys.path.insert(0, app_dir)
 
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fc_project.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fc_project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -21,5 +21,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 extend-ignore = E203,E501,C901
 max-line-length = 88
 select = C,E,F,W,B,B950
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
+exclude = .git,__pycache__,docs/source/conf.py,old,build,dist,migrations
 max-complexity = 10
 
 [isort]

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,8 @@ setup(
         "django-mptt",
         "djangorestframework",
         "reportlab",
-        "webp",
     ],
-    extras_require={"tabledetection": ["camelot-py[cv]"]},
+    extras_require={"tabledetection": ["camelot-py[cv]"], "webp": ["webp"]},
     test_requires=["factory_boy"],
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,22 @@
 
 from __future__ import print_function
 
+import codecs
 import os
 import re
-import codecs
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 
 def read(*parts):
     filename = os.path.join(os.path.dirname(__file__), *parts)
-    with codecs.open(filename, encoding='utf-8') as fp:
+    with codecs.open(filename, encoding="utf-8") as fp:
         return fp.read()
 
 
 def find_version(*file_paths):
     version_file = read(*file_paths)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
     raise RuntimeError("Unable to find version string.")
@@ -27,45 +26,41 @@ def find_version(*file_paths):
 setup(
     name="django-filingcabinet",
     version=find_version("filingcabinet", "__init__.py"),
-    url='https://github.com/okfde/django-filingcabinet',
-    license='MIT',
+    url="https://github.com/okfde/django-filingcabinet",
+    license="MIT",
     description="",
-    long_description=read('README.md'),
-    author='Stefan Wehrmeyer',
-    author_email='mail@stefanwehrmeyer.com',
+    long_description=read("README.md"),
+    author="Stefan Wehrmeyer",
+    author_email="mail@stefanwehrmeyer.com",
     packages=find_packages(exclude=("tests", "test_project")),
     install_requires=[
-        'Django',
-        'wand',
-        'pypdf2',
-        'pikepdf',
-        'Pillow',
-        'django-filter',
-        'django-json-widget',
-        'jsonschema',
-        'django-taggit',
-        'django-mptt',
-        'djangorestframework',
-        'reportlab',
-        'webp'
+        "Django",
+        "wand",
+        "pypdf2",
+        "pikepdf",
+        "Pillow",
+        "django-filter",
+        "django-json-widget",
+        "jsonschema",
+        "django-taggit",
+        "django-mptt",
+        "djangorestframework",
+        "reportlab",
+        "webp",
     ],
-    extras_require={
-        'tabledetection': ['camelot-py[cv]']
-    },
-    test_requires=[
-        'factory_boy'
-    ],
+    extras_require={"tabledetection": ["camelot-py[cv]"]},
+    test_requires=["factory_boy"],
     include_package_data=True,
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Topic :: Utilities',
-    ]
+        "Development Status :: 3 - Alpha",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Utilities",
+    ],
 )

--- a/test_project/manage.py
+++ b/test_project/manage.py
@@ -6,10 +6,10 @@ import sys
 
 def main():
     # Add directory to Python module import paht
-    app_dir = os.path.join(os.path.dirname(__file__), '..')
+    app_dir = os.path.join(os.path.dirname(__file__), "..")
     sys.path.insert(0, app_dir)
 
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'test_project.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -21,5 +21,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/test_project/test_project/app/models.py
+++ b/test_project/test_project/app/models.py
@@ -1,7 +1,4 @@
-from filingcabinet.models import (
-    AbstractDocument,
-    AbstractDocumentCollection,
-)
+from filingcabinet.models import AbstractDocument, AbstractDocumentCollection
 
 
 class Document(AbstractDocument):

--- a/test_project/test_project/settings.py
+++ b/test_project/test_project/settings.py
@@ -1,47 +1,45 @@
 import random
-
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
     }
 }
 
 INSTALLED_APPS = [
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.auth',
-    'django.contrib.messages',
-    'django.contrib.admin',
-    'django.contrib.sites',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'django_filters',
-    'taggit',
-    'django_json_widget',
-
-    'filingcabinet',
-    'test_project.app'
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.auth",
+    "django.contrib.messages",
+    "django.contrib.admin",
+    "django.contrib.sites",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "django_filters",
+    "taggit",
+    "django_json_widget",
+    "filingcabinet",
+    "test_project.app",
 ]
 
-FILINGCABINET_DOCUMENT_MODEL = 'app.Document'
-FILINGCABINET_DOCUMENTCOLLECTION_MODEL = 'app.DocumentCollection'
-FILINGCABINET_MEDIA_PUBLIC_PREFIX = 'docs'
-FILINGCABINET_MEDIA_PRIVATE_PREFIX = 'docs-private'
+FILINGCABINET_DOCUMENT_MODEL = "app.Document"
+FILINGCABINET_DOCUMENTCOLLECTION_MODEL = "app.DocumentCollection"
+FILINGCABINET_MEDIA_PUBLIC_PREFIX = "docs"
+FILINGCABINET_MEDIA_PRIVATE_PREFIX = "docs-private"
 
 
 MIDDLEWARE = [
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
-ROOT_URLCONF = 'test_project.urls'
+ROOT_URLCONF = "test_project.urls"
 
 # FIXTURE_DIRS = [os.path.join(test_dir, 'fixtures'), ]
 
@@ -49,64 +47,60 @@ SITE_ID = 1
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'DIRS': [BASE_DIR / 'test_project' / 'templates'],
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "APP_DIRS": True,
+        "DIRS": [BASE_DIR / "test_project" / "templates"],
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
             ],
         },
     },
 ]
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Enable time-zone support
 USE_TZ = True
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 # Required for django-webtest to work
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 
 # Random secret key
 
-key_chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
-SECRET_KEY = ''.join([
-    random.SystemRandom().choice(key_chars) for i in range(50)
-])
+key_chars = "abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)"
+SECRET_KEY = "".join([random.SystemRandom().choice(key_chars) for i in range(50)])
 
 # Logs all newsletter app messages to the console
 LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
         },
     },
-    'loggers': {
-        'newsletter': {
-            'handlers': ['console'],
-            'propagate': True,
+    "loggers": {
+        "newsletter": {
+            "handlers": ["console"],
+            "propagate": True,
         },
     },
 }
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.SessionAuthentication',
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
     ),
-    'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
+    "DEFAULT_PERMISSION_CLASSES": (
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ),
-    'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',
+    "DEFAULT_FILTER_BACKENDS": ("django_filters.rest_framework.DjangoFilterBackend",),
+    "DEFAULT_RENDERER_CLASSES": (
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
     ),
-    'DEFAULT_RENDERER_CLASSES': (
-        'rest_framework.renderers.JSONRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
-    )
 }

--- a/tests/test_unlisted.py
+++ b/tests/test_unlisted.py
@@ -1,7 +1,7 @@
-from django.test import TestCase
-from django.urls import reverse
 from django.conf import settings
 from django.template.defaultfilters import slugify
+from django.test import TestCase
+from django.urls import reverse
 
 import factory
 
@@ -20,7 +20,7 @@ class DocumentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Document
 
-    title = factory.Sequence(lambda n: 'Document {}'.format(n))
+    title = factory.Sequence(lambda n: "Document {}".format(n))
     slug = factory.LazyAttribute(lambda o: slugify(o.title))
 
 
@@ -28,7 +28,7 @@ class DocumentCollectionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = DocumentCollection
 
-    title = factory.Sequence(lambda n: 'DocumentCollection {}'.format(n))
+    title = factory.Sequence(lambda n: "DocumentCollection {}".format(n))
     slug = factory.LazyAttribute(lambda o: slugify(o.title))
     user = factory.SubFactory(UserFactory)
 
@@ -38,39 +38,36 @@ class DocumentAccessTest(TestCase):
         self.user = UserFactory.create()
 
     def test_unlisted_document_needs_slug(self):
-        doc = DocumentFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
-        )
+        doc = DocumentFactory.create(user=self.user, public=True, listed=False)
 
-        url = reverse('filingcabinet:document-detail_short', kwargs={
-            'pk': doc.pk,
-        })
+        url = reverse(
+            "filingcabinet:document-detail_short",
+            kwargs={
+                "pk": doc.pk,
+            },
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-        url = reverse('filingcabinet:document-detail', kwargs={
-            'pk': doc.pk,
-            'slug': doc.slug
-        })
+        url = reverse(
+            "filingcabinet:document-detail", kwargs={"pk": doc.pk, "slug": doc.slug}
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         self.client.force_login(self.user)
-        url = reverse('filingcabinet:document-detail_short', kwargs={
-            'pk': doc.pk,
-        })
+        url = reverse(
+            "filingcabinet:document-detail_short",
+            kwargs={
+                "pk": doc.pk,
+            },
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
     def test_list_unlisted_document_api(self):
-        DocumentFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
-        )
-        url = reverse('api:document-list')
+        DocumentFactory.create(user=self.user, public=True, listed=False)
+        url = reverse("api:document-list")
         response = self.client.get(url)
         self.assertEqual(len(response.json()), 0)
         self.client.force_login(self.user)
@@ -78,17 +75,13 @@ class DocumentAccessTest(TestCase):
         self.assertEqual(len(response.json()), 1)
 
     def test_retrieve_unlisted_document_api(self):
-        doc = DocumentFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
-        )
-        url = reverse('api:document-detail', kwargs={'pk': doc.pk})
+        doc = DocumentFactory.create(user=self.user, public=True, listed=False)
+        url = reverse("api:document-detail", kwargs={"pk": doc.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
-        url = reverse('api:document-detail', kwargs={'pk': doc.pk})
-        response = self.client.get(url + '?uid=' + str(doc.uid))
+        url = reverse("api:document-detail", kwargs={"pk": doc.pk})
+        response = self.client.get(url + "?uid=" + str(doc.uid))
         self.assertEqual(response.status_code, 200)
 
         self.client.force_login(self.user)
@@ -97,38 +90,38 @@ class DocumentAccessTest(TestCase):
 
     def test_unlisted_documentcollection_needs_slug(self):
         collection = DocumentCollectionFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
+            user=self.user, public=True, listed=False
         )
 
-        url = reverse('filingcabinet:document-collection_short', kwargs={
-            'pk': collection.pk,
-        })
+        url = reverse(
+            "filingcabinet:document-collection_short",
+            kwargs={
+                "pk": collection.pk,
+            },
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-        url = reverse('filingcabinet:document-collection', kwargs={
-            'pk': collection.pk,
-            'slug': collection.slug
-        })
+        url = reverse(
+            "filingcabinet:document-collection",
+            kwargs={"pk": collection.pk, "slug": collection.slug},
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         self.client.force_login(self.user)
-        url = reverse('filingcabinet:document-collection_short', kwargs={
-            'pk': collection.pk,
-        })
+        url = reverse(
+            "filingcabinet:document-collection_short",
+            kwargs={
+                "pk": collection.pk,
+            },
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
     def test_list_unlisted_documentcollection_api(self):
-        DocumentCollectionFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
-        )
-        url = reverse('api:documentcollection-list')
+        DocumentCollectionFactory.create(user=self.user, public=True, listed=False)
+        url = reverse("api:documentcollection-list")
         response = self.client.get(url)
         self.assertEqual(len(response.json()), 0)
         self.client.force_login(self.user)
@@ -137,17 +130,13 @@ class DocumentAccessTest(TestCase):
 
     def test_retrieve_unlisted_documentcollection_api(self):
         collection = DocumentCollectionFactory.create(
-            user=self.user,
-            public=True,
-            listed=False
+            user=self.user, public=True, listed=False
         )
-        url = reverse('api:documentcollection-detail', kwargs={
-            'pk': collection.pk
-        })
+        url = reverse("api:documentcollection-detail", kwargs={"pk": collection.pk})
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
 
-        response = self.client.get(url + '?uid=' + str(collection.uid))
+        response = self.client.get(url + "?uid=" + str(collection.uid))
         self.assertEqual(response.status_code, 200)
 
         self.client.force_login(self.user)


### PR DESCRIPTION
All changes in the pre-commit commit are automatically created by black and should be safe except for three:

* https://github.com/okfde/django-filingcabinet/commit/c2b73e2b80f827e2476678bcc738aceb5c9a1175#diff-56e2272179d57ef3d6a4e126432302a140f2511fe8b845c9447b585558bbfe27R210
* https://github.com/okfde/django-filingcabinet/commit/c2b73e2b80f827e2476678bcc738aceb5c9a1175#diff-56e2272179d57ef3d6a4e126432302a140f2511fe8b845c9447b585558bbfe27R357
* https://github.com/okfde/django-filingcabinet/commit/c2b73e2b80f827e2476678bcc738aceb5c9a1175#diff-b80182c4bc017f5f70fc38e25bd55435a08be07c569b9c2f46d8b2a9dbeda73eR157

I think those should be safe as well. The first two are to fix a `B007`, the third one to fix a [B008](https://github.com/PyCQA/flake8-bugbear#:~:text=with%20an%20underscore.-,b008,-%3A%20Do%20not%20perform)