### PR TITLE
🐛 Use cropbox instead of mediabox

### DIFF
--- a/filingcabinet/pdf_utils.py
+++ b/filingcabinet/pdf_utils.py
@@ -599,8 +599,8 @@ def page_to_png(pdf_reader, filename, temp_dir, page, max_dpi, max_resolution, t
     temp_out = os.path.join(temp_dir, "image")
 
     page_size = pdf_reader.pages[page - 1].cropbox
-    max_x_dpi = max_resolution / (page_size.getWidth() / 72)
-    max_y_dpi = max_resolution / (page_size.getHeight() / 72)
+    max_x_dpi = max_resolution / (page_size.width / 72)
+    max_y_dpi = max_resolution / (page_size.height / 72)
     dpi = min(max_dpi, max_x_dpi, max_y_dpi)
 
     command = [

--- a/filingcabinet/pdf_utils.py
+++ b/filingcabinet/pdf_utils.py
@@ -598,7 +598,7 @@ def get_image_from_pdf_page(
 def page_to_png(pdf_reader, filename, temp_dir, page, max_dpi, max_resolution, timeout):
     temp_out = os.path.join(temp_dir, "image")
 
-    page_size = pdf_reader.pages[page - 1].mediabox
+    page_size = pdf_reader.pages[page - 1].cropbox
     max_x_dpi = max_resolution / (page_size.getWidth() / 72)
     max_y_dpi = max_resolution / (page_size.getHeight() / 72)
     dpi = min(max_dpi, max_x_dpi, max_y_dpi)
@@ -606,6 +606,7 @@ def page_to_png(pdf_reader, filename, temp_dir, page, max_dpi, max_resolution, t
     command = [
         "pdftoppm",
         "-png",
+        "-cropbox",
         "-r",
         str(dpi),
         "-singlefile",


### PR DESCRIPTION
This also fixes an issue when redaction a pdf in froide, where after the redaction the full MediaBox would be shown again and the redactions would be in the wrong place