### PR TITLE
🥅 Catch exception in pdflib page.lines

### DIFF
--- a/src/filingcabinet/pdf_utils.py
+++ b/src/filingcabinet/pdf_utils.py
@@ -242,7 +242,10 @@ class PDFProcessor(object):
                 self.pdflib_pages = list(pdflib_doc)
         if hasattr(self, "pdflib_pages"):
             page = self.pdflib_pages[page_no - 1]
-            return " ".join(page.lines).strip()
+            try:
+                return " ".join(page.lines).strip()
+            except Exception as err:
+                logger.exception(err)
         page = self.pdf_reader.pages[page_no - 1]
         return page.extract_text()
 


### PR DESCRIPTION
If pdflib.lines fails (in our case it throws an exception because of a unicode error?), fall back to using pypdf to extract the text