### PR TITLE
🐛 Remove lazy-loading from preview sidebar

### DIFF
--- a/frontend/javascript/components/document-preview-page.vue
+++ b/frontend/javascript/components/document-preview-page.vue
@@ -13,7 +13,6 @@
         :src="imageUrl"
         alt=""
         class="img-fluid page-image"
-        loading="lazy"
         @load="onImageLoad" />
     </picture>
     <div v-if="!imageLoaded" class="spinner-grow" role="status">


### PR DESCRIPTION
The images are only shown once they are loaded, but with `loading="lazy"`, they are only loaded once they are shown 🔄