### PR TITLE
🩹 Validate that query collection id is digit

### DIFF
--- a/src/filingcabinet/api_views.py
+++ b/src/filingcabinet/api_views.py
@@ -75,10 +75,11 @@ class DocumentViewSet(
             return DocumentSerializer
 
     def can_read_unlisted_via_collection(self):
+        query = self.request.GET.get("collection")
+        if query and not query.isdigit():
+            return False
         try:
-            collection = DocumentCollection.objects.get(
-                id=self.request.GET.get("collection")
-            )
+            collection = DocumentCollection.objects.get(id=query)
         except DocumentCollection.DoesNotExist:
             return False
         return collection.can_read(self.request)


### PR DESCRIPTION
Note: This assumes that collection ids are always ints, i.e. if we ever switch to uuids, strings, etc this breaks. Alternative would be to catch `ValueError` in [this line](https://github.com/okfde/django-filingcabinet/blob/bcbd074ee7d7e7b5fa040e14b7e4d66c0525a56a/src/filingcabinet/api_views.py#L82), which imho is also not perfect