### PR TITLE
✨ push url state when navigating through collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.12', '3.13']
+        python-version: ['3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Setup uv

--- a/frontend/javascript/components/document-collection.vue
+++ b/frontend/javascript/components/document-collection.vue
@@ -285,6 +285,22 @@ export default {
     }
   },
   created() {
+    const queryParams = new URLSearchParams(window.location.search)
+
+    if (queryParams.has('document')) {
+      this.document = this.collection.documents.find(
+        (d) => d.id === parseInt(queryParams.get('document'), 10)
+      )
+
+      if (!this.document) {
+        getData(
+          `${this.config.urls.documentApiUrl}${queryParams.get('document')}/`
+        ).then((doc) => {
+          this.document = doc
+        })
+      }
+    }
+
     if (!this.documentCollection.id && this.documentCollection.resource_uri) {
       this.getCollectionData()
     }

--- a/src/filingcabinet/models.py
+++ b/src/filingcabinet/models.py
@@ -793,6 +793,9 @@ class AbstractDocumentCollection(models.Model):
             return CollectionDirectory.get_root_nodes().filter(collection=self)
         return parent_directory.get_children().filter(collection=self)
 
+    def get_parent_directories(self, directory):
+        return directory.get_ancestors().filter(collection=self)
+
     def get_absolute_url(self):
         if self.slug:
             return reverse(


### PR DESCRIPTION
This allows sharing "deep" links into the collection, by appending `?directory=123`, `?document=123`, or both.

When navigating through the collection, the URL in the browser is updated.
