### PR TITLE
prevent failing computed imageUrl

### DIFF
--- a/frontend/javascript/components/document-preview-page.vue
+++ b/frontend/javascript/components/document-preview-page.vue
@@ -1,13 +1,12 @@
 <template>
   <a :href="pageAnchor" class="document-preview-page" @click.prevent="navigate">
-    <picture>
+    <picture v-if="page.image_url">
       <source
         v-for="format in imageFormats"
         :key="format"
         :srcset="imageUrl.replace(/\.png/, '.png.' + format)"
         :type="'image/' + format" />
       <img
-        v-if="page.image_url"
         v-show="imageLoaded"
         ref="image"
         :src="imageUrl"


### PR DESCRIPTION
as seen on sentry.
imageUrl in <source srcset> can be undefined, replace throws error.

should be harmless wrt functionality - but i can't quickly test locally..